### PR TITLE
feat: redesign cards, enhance stats, improve heatmap

### DIFF
--- a/data/books.json
+++ b/data/books.json
@@ -40,7 +40,7 @@
     "aladin_item_id": null,
     "title_normalized": "The Alignment Problem",
     "authors": [],
-    "cover_url": null,
+    "cover_url": "https://books.google.com/books/content?id=KGCNEAAAQBAJ&printsec=frontcover&img=1&zoom=2&source=gbs_api",
     "cover_id": null,
     "publisher": null,
     "first_publish_year": null,
@@ -144,14 +144,17 @@
     "added_at": "2026-03-02T06:30:16.137Z",
     "aladin_item_id": null,
     "title_normalized": "The Technological Republic",
-    "authors": [],
-    "cover_url": null,
+    "authors": [
+      "Alexander C. Karp",
+      "Nicholas W. Zamiska"
+    ],
+    "cover_url": "https://books.google.com/books/content?id=SPkIEQAAQBAJ&printsec=frontcover&img=1&zoom=2&source=gbs_api",
     "cover_id": null,
     "publisher": null,
-    "first_publish_year": null,
+    "first_publish_year": 2025,
     "subjects": [],
     "pages": null,
-    "isbn": null,
+    "isbn": "9780593798706",
     "ol_key": null
   },
   {
@@ -402,7 +405,7 @@
       "수학",
       "쉽게 배우는 수학"
     ],
-    "pages": null,
+    "pages": 360,
     "isbn": "9788901165813"
   },
   {
@@ -515,7 +518,7 @@
       "컴퓨터 공학",
       "소프트웨어 공학"
     ],
-    "pages": null,
+    "pages": 328,
     "isbn": "9791140700288",
     "ol_key": null
   },
@@ -544,7 +547,7 @@
       "세계의 소설",
       "동유럽소설"
     ],
-    "pages": null,
+    "pages": 520,
     "isbn": "9788937437564",
     "ol_key": null
   },
@@ -744,7 +747,7 @@
       "심리학/정신분석학",
       "교양 심리학"
     ],
-    "pages": null,
+    "pages": 544,
     "isbn": "9788958270096"
   },
   {
@@ -771,7 +774,7 @@
       "성공",
       "성공학"
     ],
-    "pages": null,
+    "pages": 308,
     "isbn": "9791162542040"
   },
   {
@@ -825,7 +828,7 @@
       "자기계발",
       "창의적사고/두뇌계발"
     ],
-    "pages": null,
+    "pages": 333,
     "isbn": "9791162540633"
   },
   {
@@ -853,7 +856,7 @@
       "트렌드/미래전망",
       "트렌드/미래전망 일반"
     ],
-    "pages": null,
+    "pages": 336,
     "isbn": "9788991945753"
   },
   {
@@ -880,7 +883,7 @@
       "재테크/투자",
       "재테크/투자 일반"
     ],
-    "pages": null,
+    "pages": 316,
     "isbn": "9788925578354"
   },
   {
@@ -907,7 +910,7 @@
       "경제학/경제일반",
       "화폐/금융/재정"
     ],
-    "pages": null,
+    "pages": 276,
     "isbn": "9791191393163"
   },
   {
@@ -962,7 +965,7 @@
       "성공",
       "성공학"
     ],
-    "pages": null,
+    "pages": 300,
     "isbn": "9791168340213"
   },
   {
@@ -1072,7 +1075,7 @@
       "판타지/환상문학",
       "한국판타지/환상소설"
     ],
-    "pages": null,
+    "pages": 300,
     "isbn": "9791165341909"
   },
   {
@@ -1099,7 +1102,7 @@
       "판타지/환상문학",
       "한국판타지/환상소설"
     ],
-    "pages": null,
+    "pages": 308,
     "isbn": "9791165343729"
   },
   {
@@ -1125,7 +1128,7 @@
       "에세이",
       "한국에세이"
     ],
-    "pages": null,
+    "pages": 272,
     "isbn": "9788954677257"
   },
   {

--- a/scripts/backfill-pages.mjs
+++ b/scripts/backfill-pages.mjs
@@ -1,0 +1,141 @@
+// scripts/backfill-pages.mjs
+// 기존 books.json에서 pages가 null인 항목에 페이지 수를 채운다.
+// 1차: Aladin ItemLookUp (ALADIN_TTB_KEY 환경변수 필요, OptResult=subInfo)
+// 2차: Google Books API by ISBN (무료, 키 불필요)
+// 3차: Open Library by ISBN (무료, 키 불필요)
+//
+// 사용법:
+//   ALADIN_TTB_KEY=xxx node scripts/backfill-pages.mjs
+//   node scripts/backfill-pages.mjs   # Aladin 없이 Google Books만
+
+import { readFileSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+function parsePositiveInt(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.round(n);
+}
+
+function pickPageCount(book) {
+  return (
+    parsePositiveInt(book?.subInfo?.itemPage) ??
+    parsePositiveInt(book?.itemPage) ??
+    parsePositiveInt(book?.pageCount) ??
+    null
+  );
+}
+
+async function fetchPagesFromAladin(aladinItemId, ttbKey) {
+  if (!aladinItemId || !ttbKey) return null;
+  try {
+    const url = new URL('https://www.aladin.co.kr/ttb/api/ItemLookUp.aspx');
+    url.searchParams.set('ttbkey', ttbKey);
+    url.searchParams.set('itemIdType', 'ItemId');
+    url.searchParams.set('ItemId', String(aladinItemId));
+    url.searchParams.set('Cover', 'Big');
+    url.searchParams.set('output', 'js');
+    url.searchParams.set('Version', '20131101');
+    url.searchParams.set('OptResult', 'subInfo');
+
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const data = await res.json();
+    const detail = Array.isArray(data.item) ? data.item[0] : null;
+    if (!detail) return null;
+    const pages = pickPageCount(detail);
+    if (pages) console.log(`  [Aladin] ${pages}p`);
+    return pages;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchPagesFromGoogleBooks(isbn) {
+  if (!isbn) return null;
+  try {
+    const url = `https://www.googleapis.com/books/v1/volumes?q=isbn:${encodeURIComponent(isbn)}&maxResults=1`;
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const data = await res.json();
+    const vol = data?.items?.[0]?.volumeInfo;
+    if (!vol) return null;
+    const pages = parsePositiveInt(vol.pageCount);
+    if (pages) console.log(`  [Google Books] ${pages}p`);
+    return pages;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchPagesFromOpenLibrary(isbn) {
+  if (!isbn) return null;
+  try {
+    const url = `https://openlibrary.org/api/books?bibkeys=ISBN:${encodeURIComponent(isbn)}&jscmd=data&format=json`;
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const data = await res.json();
+    const key = `ISBN:${isbn}`;
+    const pages = parsePositiveInt(data?.[key]?.number_of_pages);
+    if (pages) console.log(`  [Open Library] ${pages}p`);
+    return pages;
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const ttbKey = process.env.ALADIN_TTB_KEY ?? null;
+  const dataPath = resolve(process.cwd(), 'data', 'books.json');
+  const books = JSON.parse(readFileSync(dataPath, 'utf-8'));
+
+  const targets = books.filter(b => !b.pages || b.pages === 0);
+  console.log(`[backfill-pages] ${targets.length}권에 페이지 수가 없음. 채우기 시작...`);
+  if (!ttbKey) {
+    console.log('[backfill-pages] ALADIN_TTB_KEY 없음 → Google Books + Open Library만 사용');
+  }
+
+  let updated = 0;
+  for (const book of books) {
+    if (book.pages && book.pages > 0) continue;
+
+    const title = book.user_title || book.title_normalized || '(제목 없음)';
+    console.log(`\n처리 중: "${title}" (id=${book.id}, isbn=${book.isbn ?? '없음'})`);
+
+    let pages = null;
+
+    // 1차: Aladin (TTB Key 있을 때)
+    if (ttbKey && book.aladin_item_id) {
+      pages = await fetchPagesFromAladin(book.aladin_item_id, ttbKey);
+    }
+
+    // 2차: Google Books by ISBN
+    if (!pages && book.isbn) {
+      pages = await fetchPagesFromGoogleBooks(book.isbn);
+    }
+
+    // 3차: Open Library by ISBN
+    if (!pages && book.isbn) {
+      pages = await fetchPagesFromOpenLibrary(book.isbn);
+    }
+
+    if (pages) {
+      book.pages = pages;
+      updated++;
+      console.log(`  → 업데이트: ${pages}p`);
+    } else {
+      console.log(`  → 페이지 수 없음 (수동 입력 필요)`);
+    }
+
+    // API 과부하 방지 딜레이
+    await new Promise(r => setTimeout(r, 300));
+  }
+
+  writeFileSync(dataPath, JSON.stringify(books, null, 2) + '\n');
+  console.log(`\n[backfill-pages] 완료: ${updated}/${targets.length}권 업데이트`);
+}
+
+main().catch(err => {
+  console.error('[error]', err);
+  process.exit(1);
+});

--- a/scripts/process-book.mjs
+++ b/scripts/process-book.mjs
@@ -79,6 +79,7 @@ async function fetchAladinItemDetail(itemId, ttbKey) {
     url.searchParams.set('Cover', 'Big');
     url.searchParams.set('output', 'js');
     url.searchParams.set('Version', '20131101');
+    url.searchParams.set('OptResult', 'subInfo');
 
     const res = await fetch(url);
     if (!res.ok) {

--- a/src/src/components/BookCard.astro
+++ b/src/src/components/BookCard.astro
@@ -36,13 +36,22 @@ function fmtDate(d: string | null | undefined) {
     year: 'numeric', month: 'numeric', day: 'numeric',
   });
 }
-
 const finishStr = fmtDate(book.finish_date);
+
+// 저자: 첫 저자 + "외 N명"
+const authorDisplay = (() => {
+  const authors = book.authors ?? [];
+  if (authors.length === 0) return null;
+  if (authors.length === 1) return authors[0];
+  return `${authors[0]} 외 ${authors.length - 1}명`;
+})();
+
+const pagesStr = book.pages ? `${book.pages.toLocaleString('ko-KR')}p` : null;
 ---
 
 <article class="group cursor-default" style="color: var(--text-1)">
   <!-- Cover -->
-  <div class="aspect-[3/4] sm:aspect-[2/3] overflow-hidden rounded-sm mb-3"
+  <div class="relative aspect-[2/3] overflow-hidden rounded-sm mb-3"
        style="background: var(--border);">
     <img
       src={coverUrl}
@@ -60,24 +69,23 @@ const finishStr = fmtDate(book.finish_date);
       {displayTitle}
     </h3>
 
-    {book.authors && book.authors.length > 0 && (
-      <p class="text-[11px] truncate" style="color: var(--text-2)">
-        {book.authors.join(', ')}
-      </p>
+    {authorDisplay && (
+      <p class="text-[11px] truncate" style="color: var(--text-2)">{authorDisplay}</p>
     )}
 
     <div class="flex items-center justify-between gap-2">
       {finishStr
-        ? <span class="text-[11px] font-mono" style="color: var(--text-3)">
-            {finishStr}
-            {book.reading_days && ` · ${book.reading_days}일`}
-          </span>
+        ? <span class="text-[11px] font-mono" style="color: var(--text-3)">{finishStr}</span>
         : <span class="text-[11px] font-mono" style="color: var(--text-3)">날짜 미상</span>
       }
       <span class="text-[11px] font-mono shrink-0" style="color: var(--accent)">
         ★ {book.rating}
       </span>
     </div>
+
+    {pagesStr && (
+      <p class="text-[11px] font-mono" style="color: var(--text-3)">{pagesStr}</p>
+    )}
 
     {book.review && (
       <p class="text-[11px] leading-relaxed line-clamp-2 pt-0.5" style="color: var(--text-2)">

--- a/src/src/components/HeatmapCalendar.astro
+++ b/src/src/components/HeatmapCalendar.astro
@@ -1,9 +1,10 @@
 ---
-import { formatYyyyMmDd, parseYyyyMmDd } from '../lib/date';
+import { parseYyyyMmDd } from '../lib/date';
 
 interface Activity {
-  date: string;   // "YYYY-MM-DD"
-  count: number;
+  date: string;       // "YYYY-MM-DD"
+  movieCount: number;
+  bookCount: number;
 }
 interface Props {
   data: Activity[];
@@ -12,8 +13,10 @@ interface Props {
 const { data } = Astro.props;
 
 // Build a map for O(1) lookup
-const byDate: Record<string, number> = {};
-for (const { date, count } of data) byDate[date] = count;
+const byDate: Record<string, { movieCount: number; bookCount: number }> = {};
+for (const { date, movieCount, bookCount } of data) {
+  byDate[date] = { movieCount, bookCount };
+}
 
 // Build 53-week grid ending today
 const today = new Date();
@@ -24,20 +27,27 @@ const startDate = new Date(today);
 startDate.setDate(startDate.getDate() - 52 * 7 - startDate.getDay());
 
 // Build week columns
-const weeks: { iso: string; count: number }[][] = [];
+interface Cell {
+  iso: string;
+  movieCount: number;
+  bookCount: number;
+  isFuture: boolean;
+}
+const weeks: Cell[][] = [];
 let cursor = new Date(startDate);
 while (cursor <= today) {
-  const week: { iso: string; count: number }[] = [];
+  const week: Cell[] = [];
   for (let dow = 0; dow < 7; dow++) {
-    const iso = formatYyyyMmDd(cursor);
+    const iso = `${cursor.getFullYear()}-${String(cursor.getMonth()+1).padStart(2,'0')}-${String(cursor.getDate()).padStart(2,'0')}`;
     const isFuture = cursor > today;
-    week.push({ iso, count: isFuture ? -1 : (byDate[iso] ?? 0) });
+    const entry = byDate[iso] ?? { movieCount: 0, bookCount: 0 };
+    week.push({ iso, movieCount: entry.movieCount, bookCount: entry.bookCount, isFuture });
     cursor.setDate(cursor.getDate() + 1);
   }
   weeks.push(week);
 }
 
-// Month labels: one per month, positioned at the week where it starts
+// Month labels
 const monthLabels: { label: string; col: number }[] = [];
 let lastMonth = -1;
 for (let w = 0; w < weeks.length; w++) {
@@ -50,6 +60,27 @@ for (let w = 0; w < weeks.length; w++) {
     monthLabels.push({ label: monthNames[m], col: w });
     lastMonth = m;
   }
+}
+
+// Compute cell CSS class + tooltip per cell
+function cellClass(cell: Cell): string {
+  if (cell.isFuture) return 'heatmap-cell future';
+  const { movieCount, bookCount } = cell;
+  if (movieCount === 0 && bookCount === 0) return 'heatmap-cell empty';
+
+  const type = movieCount > 0 && bookCount > 0 ? 'both'
+             : movieCount > 0 ? 'movie'
+             : 'book';
+  return `heatmap-cell ${type}`;
+}
+
+function cellTitle(cell: Cell): string {
+  if (cell.isFuture) return '';
+  const { iso, movieCount, bookCount } = cell;
+  const parts: string[] = [];
+  if (movieCount > 0) parts.push(`영화 ${movieCount}편`);
+  if (bookCount > 0) parts.push(`책 ${bookCount}건`);
+  return parts.length > 0 ? `${iso} — ${parts.join(', ')}` : iso;
 }
 ---
 
@@ -66,14 +97,24 @@ for (let w = 0; w < weeks.length; w++) {
   <div class="heatmap-grid" style={`grid-template-columns: repeat(${weeks.length}, 1fr);`}>
     {weeks.map(week => (
       <div class="heatmap-week">
-        {week.map(({ iso, count }) => (
-          <div
-            class={`heatmap-cell ${count < 0 ? 'future' : count === 0 ? 'empty' : count === 1 ? 'l1' : count === 2 ? 'l2' : count <= 4 ? 'l3' : 'l4'}`}
-            title={count >= 0 ? `${iso}${count > 0 ? ` — ${count}개` : ''}` : ''}
-          />
+        {week.map(cell => (
+          <div class={cellClass(cell)} title={cellTitle(cell)} />
         ))}
       </div>
     ))}
+  </div>
+
+  <!-- Legend -->
+  <div class="heatmap-legend">
+    <span class="legend-item">
+      <span class="legend-dot movie"></span>영화
+    </span>
+    <span class="legend-item">
+      <span class="legend-dot book"></span>책
+    </span>
+    <span class="legend-item">
+      <span class="legend-dot both"></span>둘 다
+    </span>
   </div>
 </div>
 
@@ -83,6 +124,7 @@ for (let w = 0; w < weeks.length; w++) {
     padding-bottom: 4px;
   }
 
+  /* ── 월 레이블 ── */
   .heatmap-months {
     display: grid;
     margin-bottom: 4px;
@@ -96,18 +138,17 @@ for (let w = 0; w < weeks.length; w++) {
     line-height: 1;
   }
 
+  /* ── 셀 그리드 ── */
   .heatmap-grid {
     display: grid;
     gap: 3px;
     min-width: max-content;
   }
-
   .heatmap-week {
     display: flex;
     flex-direction: column;
     gap: 3px;
   }
-
   .heatmap-cell {
     width: 12px;
     height: 12px;
@@ -115,20 +156,52 @@ for (let w = 0; w < weeks.length; w++) {
     flex-shrink: 0;
   }
 
-  /* Light mode */
-  .heatmap-cell.future  { background: transparent; }
-  .heatmap-cell.empty   { background: var(--border); }
-  .heatmap-cell.l1      { background: #c9933a44; }
-  .heatmap-cell.l2      { background: #c9933a88; }
-  .heatmap-cell.l3      { background: #c9933acc; }
-  .heatmap-cell.l4      { background: #c9933a; }
+  /* ── 공통 ── */
+  .heatmap-cell.future { background: transparent; }
+  .heatmap-cell.empty  { background: var(--border); }
 
-  /* Dark mode */
-  :global(html.dark) .heatmap-cell.empty { background: var(--border); }
-  :global(html.dark) .heatmap-cell.l1   { background: #5a3e10; }
-  :global(html.dark) .heatmap-cell.l2   { background: #8a5f1a; }
-  :global(html.dark) .heatmap-cell.l3   { background: #b8832a; }
-  :global(html.dark) .heatmap-cell.l4   { background: #d4a853; }
+  /* ── 영화 (Gold / Accent) ── */
+  .heatmap-cell.movie { background: #c9933a; }
+
+  /* ── 책 (Steel Blue) ── */
+  .heatmap-cell.book  { background: #5c84b0; }
+
+  /* ── 영화 + 책 (Soft Purple) ── */
+  .heatmap-cell.both  { background: #7b64b4; }
+
+  /* ── 다크 모드 ── */
+  :global(html.dark) .heatmap-cell.empty  { background: var(--border); }
+  :global(html.dark) .heatmap-cell.movie  { background: #d4a853; }
+  :global(html.dark) .heatmap-cell.book   { background: #5a90c8; }
+  :global(html.dark) .heatmap-cell.both   { background: #9070c8; }
+
+  /* ── 범례 ── */
+  .heatmap-legend {
+    display: flex;
+    gap: 1rem;
+    margin-top: 10px;
+  }
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 10px;
+    font-family: "JetBrains Mono", monospace;
+    color: var(--text-3);
+  }
+  .legend-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+  .legend-dot.movie { background: #c9933a; }
+  .legend-dot.book  { background: #5c84b0; }
+  .legend-dot.both  { background: #7b64b4; }
+
+  :global(html.dark) .legend-dot.movie { background: #d4a853; }
+  :global(html.dark) .legend-dot.book  { background: #5a90c8; }
+  :global(html.dark) .legend-dot.both  { background: #9070c8; }
 
   @media (max-width: 640px) {
     .heatmap-cell { width: 10px; height: 10px; }

--- a/src/src/components/MovieCard.astro
+++ b/src/src/components/MovieCard.astro
@@ -25,21 +25,37 @@ const posterUrl = movie.poster_path
 
 const displayTitle = movie.title_ko || movie.user_title || '';
 
+// 원제가 한국어 제목과 다른 경우에만 표시
+const showOriginal = movie.title_original &&
+  movie.title_original !== displayTitle &&
+  movie.title_original !== movie.title_ko;
+
 const dateStr = movie.watched_date
   ? new Date(movie.watched_date + 'T12:00:00').toLocaleDateString('ko-KR', {
       year: 'numeric', month: 'numeric', day: 'numeric',
     })
   : null;
+
+// 런타임 포맷: 117분 → "1h 57m"
+function fmtRuntime(min: number) {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return h > 0 ? (m > 0 ? `${h}h ${m}m` : `${h}h`) : `${m}m`;
+}
+
+const runtimeStr = movie.runtime && movie.runtime > 0 ? fmtRuntime(movie.runtime) : null;
+
+// 장르 최대 2개
+const topGenres = (movie.genres ?? []).slice(0, 2);
 ---
 
 <!--
-  Poster-dominant card: image fills 100%, info is minimal below.
-  No overlays, no chips, no badges stacked on each other.
-  Hover reveals a very subtle lift — not a glow party.
+  Cinematic card: poster with gradient overlay for title, runtime badge, genre chips.
+  Minimal info below — date, rating, review only.
 -->
 <article class="group cursor-default" style="color: var(--text-1)">
-  <!-- Poster -->
-  <div class="aspect-[3/4] sm:aspect-[2/3] overflow-hidden rounded-sm mb-3"
+  <!-- Poster with cinematic overlay -->
+  <div class="relative aspect-[2/3] overflow-hidden rounded-sm mb-3"
        style="background: var(--border);">
     <img
       src={posterUrl}
@@ -49,14 +65,48 @@ const dateStr = movie.watched_date
       class="w-full h-full object-cover transition-transform duration-500 ease-out group-hover:scale-[1.03]"
       onerror={`this.src='${base}/placeholder-movie.svg'`}
     />
+
+    <!-- Runtime badge (top-right) -->
+    {runtimeStr && (
+      <span class="absolute top-2 right-2 font-mono text-white rounded-sm px-1.5 py-0.5"
+            style="font-size: 9px; background: rgba(0,0,0,0.65); letter-spacing: 0.05em;">
+        {runtimeStr}
+      </span>
+    )}
+
+    <!-- Bottom cinematic overlay: genres + title -->
+    <div class="absolute bottom-0 left-0 right-0 px-2.5 pb-2.5 pt-8 transition-opacity duration-300"
+         style="background: linear-gradient(to top, rgba(0,0,0,0.82) 0%, rgba(0,0,0,0.4) 60%, transparent 100%);">
+
+      <!-- Genre chips -->
+      {topGenres.length > 0 && (
+        <div class="flex flex-wrap gap-1 mb-1.5">
+          {topGenres.map(genre => (
+            <span class="font-mono text-white rounded-sm px-1 py-0.5"
+                  style="font-size: 8px; letter-spacing: 0.12em; text-transform: uppercase; background: rgba(255,255,255,0.18);">
+              {genre}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <!-- Title in overlay -->
+      <h3 class="text-sm font-semibold leading-snug line-clamp-2 text-white">
+        {displayTitle}
+      </h3>
+
+      <!-- Original title if different -->
+      {showOriginal && (
+        <p class="font-mono text-white/60 leading-tight mt-0.5 line-clamp-1"
+           style="font-size: 9px;">
+          {movie.title_original}
+        </p>
+      )}
+    </div>
   </div>
 
-  <!-- Info: absolutely minimal -->
+  <!-- Info below poster: date + rating + review only -->
   <div class="space-y-0.5 px-0.5">
-    <h3 class="text-sm font-medium leading-snug line-clamp-2" style="color: var(--text-1)">
-      {displayTitle}
-    </h3>
-
     <div class="flex items-center justify-between gap-2">
       {dateStr
         ? <span class="text-[11px] font-mono" style="color: var(--text-3)">{dateStr}</span>

--- a/src/src/components/NavBar.astro
+++ b/src/src/components/NavBar.astro
@@ -41,6 +41,23 @@ const currentPath = Astro.url.pathname;
           </a>
         );
       })}
+
+      <!-- Divider -->
+      <span class="mx-1" style="color: var(--border);">|</span>
+
+      <!-- Blog external link -->
+      <a
+        href="https://kbsooo.github.io"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="px-3 py-1.5 rounded-md text-sm transition-colors flex items-center gap-1"
+        style="color: var(--text-3);"
+      >
+        블로그
+        <svg width="10" height="10" viewBox="0 0 10 10" fill="none" style="opacity:0.5;">
+          <path d="M1.5 8.5L8.5 1.5M8.5 1.5H4M8.5 1.5V6" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </a>
     </div>
 
     <ThemeToggle />

--- a/src/src/components/StatsPanel.astro
+++ b/src/src/components/StatsPanel.astro
@@ -31,7 +31,7 @@ const totalMovies = movies.length;
 const totalBooks  = books.length;
 ---
 
-<div class="mb-14 pb-10 grid grid-cols-1 sm:grid-cols-3 gap-4"
+<div class="mb-14 pb-10 grid grid-cols-3 gap-2 sm:gap-6"
      style="border-bottom: 1px solid var(--border)">
 
   <!-- This month -->
@@ -46,7 +46,7 @@ const totalBooks  = books.length;
   </div>
 
   <!-- This year -->
-  <div class="stat-cell sm:border-l sm:pl-8" style="border-color: var(--border);">
+  <div class="stat-cell border-l pl-3 sm:pl-8" style="border-color: var(--border);">
     <p class="label mb-2">올해</p>
     <p class="display-num">{moviesThisYear + booksThisYear}</p>
     <p class="text-xs font-mono mt-1" style="color: var(--text-3)">
@@ -55,7 +55,7 @@ const totalBooks  = books.length;
   </div>
 
   <!-- Lifetime totals -->
-  <div class="stat-cell sm:border-l sm:pl-8" style="border-color: var(--border);">
+  <div class="stat-cell border-l pl-3 sm:pl-8" style="border-color: var(--border);">
     <p class="label mb-2">전체</p>
     <p class="display-num">{totalMovies + totalBooks}</p>
     <p class="text-xs font-mono mt-1" style="color: var(--text-3)">

--- a/src/src/pages/index.astro
+++ b/src/src/pages/index.astro
@@ -5,31 +5,31 @@ import StatsPanel from '../components/StatsPanel.astro';
 import HeatmapCalendar from '../components/HeatmapCalendar.astro';
 import MovieCard from '../components/MovieCard.astro';
 import BookCard from '../components/BookCard.astro';
-import { formatYyyyMmDd, parseYyyyMmDd } from '../lib/date';
 
 import moviesRaw from '../../../data/movies.json';
 import booksRaw from '../../../data/books.json';
 
-// Heatmap: movies by watched_date, books by full reading span
-const activityMap = new Map<string, number>();
+// Heatmap: movies by watched_date, books by start_date + finish_date events only
+interface ActivityEntry { movieCount: number; bookCount: number; }
+const activityMap = new Map<string, ActivityEntry>();
+const getOrCreate = (date: string): ActivityEntry => {
+  if (!activityMap.has(date)) activityMap.set(date, { movieCount: 0, bookCount: 0 });
+  return activityMap.get(date)!;
+};
 
 for (const m of moviesRaw) {
   if (!m.watched_date) continue;
-  activityMap.set(m.watched_date, (activityMap.get(m.watched_date) ?? 0) + 1);
+  getOrCreate(m.watched_date).movieCount++;
 }
 for (const b of booksRaw) {
-  if (!b.finish_date) continue;
-  const start = parseYyyyMmDd(b.start_date) ?? parseYyyyMmDd(b.finish_date);
-  const end = parseYyyyMmDd(b.finish_date);
-  if (!start || !end) continue;
-  const cursor = new Date(start);
-  while (cursor <= end) {
-    const d = formatYyyyMmDd(cursor);
-    activityMap.set(d, (activityMap.get(d) ?? 0) + 1);
-    cursor.setDate(cursor.getDate() + 1);
-  }
+  // 시작일 (책 산 날 / 읽기 시작한 날)
+  if (b.start_date) getOrCreate(b.start_date).bookCount++;
+  // 완독일 — start_date와 같은 날이어도 별도 이벤트로 카운트
+  if (b.finish_date) getOrCreate(b.finish_date).bookCount++;
 }
-let activityData = Array.from(activityMap.entries()).map(([date, count]) => ({ date, count }));
+const activityData = Array.from(activityMap.entries()).map(([date, { movieCount, bookCount }]) => ({
+  date, movieCount, bookCount,
+}));
 
 // Sort recent movies/books — dated first
 const recentMovies = [...moviesRaw]

--- a/src/src/pages/stats.astro
+++ b/src/src/pages/stats.astro
@@ -30,8 +30,85 @@ const avgPages = pageKnownBooks.length > 0
   ? Math.round(totalPages / pageKnownBooks.length)
   : null;
 const pageUnknownBooks = totalBooks - pageKnownBooks.length;
-const readingDaysKnownBooks = books.filter(b => Number.isFinite(b.reading_days) && (b.reading_days ?? 0) >= 0);
-const totalReadingDays = readingDaysKnownBooks.reduce((sum, b) => sum + (b.reading_days ?? 0), 0);
+
+// ─── 하이라이트 데이터 ──────────────────────────────────────────────────────
+
+// 가장 긴 영화
+const longestMovie = runtimeKnownMovies.length > 0
+  ? runtimeKnownMovies.reduce((best, m) => (m.runtime ?? 0) > (best.runtime ?? 0) ? m : best)
+  : null;
+function fmtRuntime(min: number) {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return h > 0 ? (m > 0 ? `${h}h ${m}m` : `${h}h`) : `${m}m`;
+}
+
+// 내 평점이 TMDB 평점보다 가장 많이 높은 영화 (편애)
+const tmdbMovies = movies.filter(m => m.tmdb_rating && Number.isFinite(m.tmdb_rating) && Number.isFinite(m.rating));
+const mostLovedMovie = tmdbMovies.length > 0
+  ? tmdbMovies.reduce((best, m) =>
+      (m.rating - (m.tmdb_rating ?? 0)) > (best.rating - (best.tmdb_rating ?? 0)) ? m : best
+    )
+  : null;
+const lovedDelta = mostLovedMovie
+  ? (mostLovedMovie.rating - (mostLovedMovie.tmdb_rating ?? 0)).toFixed(1)
+  : null;
+
+// 가장 두꺼운 책
+const thickestBook = pageKnownBooks.length > 0
+  ? pageKnownBooks.reduce((best, b) => (b.pages ?? 0) > (best.pages ?? 0) ? b : best)
+  : null;
+
+// ─── 페이지 기반 재미 통계 ──────────────────────────────────────────────────
+
+// 읽은 책을 쌓으면 몇 cm? (일반 책 1페이지 ≈ 0.1mm = 0.01cm)
+const PAGE_THICKNESS_MM = 0.1; // mm per page
+const stackHeightMm = totalPages * PAGE_THICKNESS_MM;
+const stackHeightCm = stackHeightMm / 10;
+
+// 해리포터 전 시리즈 비교 (국내판 기준 약 4,200p)
+const HP_SERIES_PAGES = 4200;
+const hpRatio = totalPages > 0 ? (totalPages / HP_SERIES_PAGES).toFixed(1) : null;
+
+// 비교 랜드마크 (mm 기준)
+const LANDMARKS = [
+  { name: '63빌딩', heightMm: 249_000 },
+  { name: 'N서울타워', heightMm: 236_000 },
+  { name: '롯데타워', heightMm: 555_000 },
+  { name: '에베레스트', heightMm: 8_849_000 },
+  { name: '한강 다리(마포대교)', heightMm: 1_400_000 },
+  { name: '성인 평균 키', heightMm: 1_720 },
+  { name: '아파트 1층', heightMm: 2_800 },
+  { name: '기린', heightMm: 5_500 },
+  { name: '전봇대', heightMm: 10_000 },
+  { name: '교실', heightMm: 2_700 },
+  { name: '남산', heightMm: 262_000 },
+] as const;
+
+type Landmark = { name: string; heightMm: number };
+const closestLandmark: Landmark | null = pageKnownBooks.length > 0
+  ? LANDMARKS.reduce((closest: Landmark, l: Landmark) =>
+      Math.abs(l.heightMm - stackHeightMm) < Math.abs(closest.heightMm - stackHeightMm) ? l : closest
+    )
+  : null;
+
+const landmarkRatioPct = closestLandmark
+  ? ((stackHeightMm / closestLandmark.heightMm) * 100).toFixed(1)
+  : null;
+
+// ─── TMDB 평점 성향 ─────────────────────────────────────────────────────────
+
+// 내 평점 평균 vs TMDB 평점 평균 차이 (전체)
+const ratingBias = tmdbMovies.length > 0
+  ? tmdbMovies.reduce((s, m) => s + (m.rating - (m.tmdb_rating ?? 0)), 0) / tmdbMovies.length
+  : 0;
+const higherThanTmdb = tmdbMovies.filter(m => m.rating > (m.tmdb_rating ?? 0)).length;
+const lowerThanTmdb = tmdbMovies.filter(m => m.rating < (m.tmdb_rating ?? 0)).length;
+const sameTmdb = tmdbMovies.filter(m => m.rating === (m.tmdb_rating ?? 0)).length;
+// 성향 레이블
+const biasLabel = ratingBias > 0.5 ? '관대한 편' : ratingBias < -0.5 ? '까다로운 편' : '평균적';
+
+// ─── 장르/주제 차트 ────────────────────────────────────────────────────────
 
 const movieGenreMap = new Map<string, number>();
 for (const movie of movies) {
@@ -57,8 +134,70 @@ const topBookSubjects = Array.from(bookSubjectMap.entries())
   .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
   .slice(0, 8);
 
+// ─── 평점 분포 ─────────────────────────────────────────────────────────────
+
+const movieRatingDist: [string, number][] = Array.from({length: 10}, (_, i) => {
+  const r = i + 1;
+  return [`★${r}`, movies.filter(m => m.rating === r).length] as [string, number];
+}).filter(([, c]) => c > 0);
+
+const bookRatingDist: [string, number][] = Array.from({length: 10}, (_, i) => {
+  const r = i + 1;
+  return [`★${r}`, books.filter(b => b.rating === r).length] as [string, number];
+}).filter(([, c]) => c > 0);
+
+// ─── 요일별 영화 시청 패턴 ──────────────────────────────────────────────────
+
+const weekdayLabels = ['일', '월', '화', '수', '목', '금', '토'];
+const weekdayCounts = Array(7).fill(0) as number[];
+for (const m of movies) {
+  if (m.watched_date) {
+    const d = new Date(m.watched_date + 'T12:00:00');
+    weekdayCounts[d.getDay()]++;
+  }
+}
+const weekdayData: [string, number][] = weekdayLabels.map((label, i) => [label, weekdayCounts[i]]);
+const hasWeekdayData = weekdayCounts.some(c => c > 0);
+
+// ─── 영화 개봉 연도 분포 ────────────────────────────────────────────────────
+
+const movieYearMap = new Map<string, number>();
+for (const m of movies) {
+  const year = m.release_date?.slice(0, 4);
+  if (year && /^\d{4}$/.test(year)) {
+    movieYearMap.set(year, (movieYearMap.get(year) ?? 0) + 1);
+  }
+}
+const movieYearDist: [string, number][] = Array.from(movieYearMap.entries())
+  .sort((a, b) => a[0].localeCompare(b[0]));
+const hasMovieYearData = movieYearDist.length > 0;
+
+// ─── 책 출판 연도 구간 분포 ─────────────────────────────────────────────────
+
+const bookYearBands: [string, (y: number) => boolean][] = [
+  ['~2015',  (y) => y <= 2015],
+  ['2016-19',(y) => y >= 2016 && y <= 2019],
+  ['2020-21',(y) => y >= 2020 && y <= 2021],
+  ['2022',   (y) => y === 2022],
+  ['2023',   (y) => y === 2023],
+  ['2024',   (y) => y === 2024],
+  ['2025+',  (y) => y >= 2025],
+];
+const bookYearDist: [string, number][] = bookYearBands
+  .map(([label, fn]) => [
+    label,
+    books.filter(b => b.first_publish_year && fn(b.first_publish_year)).length
+  ] as [string, number])
+  .filter(([, c]) => c > 0);
+const hasBookYearData = bookYearDist.length > 0;
+
+// ─── 월별 활동 (스택드: 영화 + 책) ────────────────────────────────────────
+
 const now = new Date();
-const monthlyRows = [];
+const monthlyRows: {
+  key: string; label: string;
+  total: number; movieCount: number; bookCount: number;
+}[] = [];
 for (let i = 11; i >= 0; i--) {
   const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
   const monthKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
@@ -90,7 +229,83 @@ const base = rawBase.endsWith('/') ? rawBase.slice(0, -1) : rawBase;
     </p>
   </div>
 
-  <section class="mb-14 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+  <!-- ── 하이라이트 카드 (Spotify Wrapped 스타일) ──────────────────────────── -->
+  {(pageKnownBooks.length > 0 || longestMovie || mostLovedMovie || thickestBook) && (
+    <section class="mb-10">
+      <p class="label mb-4">하이라이트</p>
+      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+
+        {/* BOOK TOWER */}
+        {pageKnownBooks.length > 0 && stackHeightCm > 0 && (
+          <div class="stat-box highlight-card">
+            <p class="label mb-2 text-[10px]" style="color: var(--accent)">BOOK TOWER</p>
+            <p class="display-num" style="font-size: 1.75rem;">
+              {stackHeightCm >= 100
+                ? `${(stackHeightCm / 100).toFixed(2)}m`
+                : `${stackHeightCm.toFixed(1)}cm`}
+            </p>
+            <p class="text-xs font-mono mt-1" style="color: var(--text-3)">읽은 책을 쌓은 높이</p>
+            {closestLandmark && landmarkRatioPct && (
+              <p class="text-[11px] font-mono mt-2" style="color: var(--text-2)">
+                {closestLandmark.name}의 {landmarkRatioPct}%
+              </p>
+            )}
+            {hpRatio && (
+              <p class="text-[11px] font-mono mt-0.5" style="color: var(--text-3)">
+                해리포터 시리즈의 {hpRatio}배
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* THICKEST BOOK */}
+        {thickestBook && (
+          <div class="stat-box highlight-card">
+            <p class="label mb-2 text-[10px]" style="color: var(--accent)">THICKEST BOOK</p>
+            <p class="display-num" style="font-size: 1.75rem;">{thickestBook.pages!.toLocaleString('ko-KR')}p</p>
+            <p class="text-xs font-mono mt-1" style="color: var(--text-3)">가장 두꺼운 책</p>
+            <p class="text-xs mt-2 line-clamp-1 font-medium" style="color: var(--text-2)">
+              {(thickestBook as any).user_title || (thickestBook as any).title_normalized}
+            </p>
+          </div>
+        )}
+
+        {/* LONGEST WATCH */}
+        {longestMovie && (
+          <div class="stat-box highlight-card">
+            <p class="label mb-2 text-[10px]" style="color: var(--accent)">LONGEST WATCH</p>
+            <p class="display-num" style="font-size: 1.75rem;">{fmtRuntime(longestMovie.runtime!)}</p>
+            <p class="text-xs font-mono mt-1" style="color: var(--text-3)">러닝타임</p>
+            <p class="text-xs mt-2 line-clamp-1 font-medium" style="color: var(--text-2)">
+              {longestMovie.title_ko || longestMovie.user_title}
+            </p>
+            <p class="text-[11px] font-mono mt-0.5" style="color: var(--text-3)">
+              {longestMovie.runtime}분
+            </p>
+          </div>
+        )}
+
+        {/* MY PICK */}
+        {mostLovedMovie && lovedDelta && Number(lovedDelta) > 0 && (
+          <div class="stat-box highlight-card">
+            <p class="label mb-2 text-[10px]" style="color: var(--accent)">MY PICK</p>
+            <p class="display-num" style="font-size: 1.75rem;">+{lovedDelta}</p>
+            <p class="text-xs font-mono mt-1" style="color: var(--text-3)">TMDB 대비 내 평점</p>
+            <p class="text-xs mt-2 line-clamp-1 font-medium" style="color: var(--text-2)">
+              {mostLovedMovie.title_ko || mostLovedMovie.user_title}
+            </p>
+            <p class="text-[11px] font-mono mt-0.5" style="color: var(--text-3)">
+              내 ★{mostLovedMovie.rating} · TMDB {(mostLovedMovie.tmdb_rating ?? 0).toFixed(1)}
+            </p>
+          </div>
+        )}
+
+      </div>
+    </section>
+  )}
+
+  <!-- ── 기본 수치 박스 ──────────────────────────────────────────────────────── -->
+  <section class="mb-14 grid gap-4 sm:grid-cols-3">
     <div class="stat-box">
       <p class="label mb-2">영화 시청 시간</p>
       <p class="display-num">{totalRuntimeHour.toFixed(1)}h</p>
@@ -118,22 +333,67 @@ const base = rawBase.endsWith('/') ? rawBase.slice(0, -1) : rawBase;
     </div>
 
     <div class="stat-box">
-      <p class="label mb-2">독서 기간</p>
-      <p class="display-num">{totalReadingDays.toLocaleString('ko-KR')}d</p>
-      <p class="text-xs font-mono mt-1" style="color: var(--text-3)">
-        일수 기록된 책 {readingDaysKnownBooks.length}권
-      </p>
-    </div>
-
-    <div class="stat-box">
       <p class="label mb-2">콘텐츠 수</p>
       <p class="display-num">{(totalMovies + totalBooks).toLocaleString('ko-KR')}</p>
       <p class="text-xs font-mono mt-1" style="color: var(--text-3)">
         영화 {totalMovies} · 책 {totalBooks}
       </p>
+      {tmdbMovies.length > 0 && (
+        <p class="text-[11px] mt-1" style="color: var(--text-3)">
+          평점 성향: {biasLabel} ({ratingBias > 0 ? '+' : ''}{ratingBias.toFixed(1)} vs TMDB)
+        </p>
+      )}
     </div>
   </section>
 
+  <!-- ── 평점 분포 ───────────────────────────────────────────────────────────── -->
+  {(movieRatingDist.length > 0 || bookRatingDist.length > 0) && (
+    <section class="mb-14 grid gap-8 lg:grid-cols-2">
+      {movieRatingDist.length > 0 && (
+        <div class="stat-box">
+          <div class="flex items-baseline justify-between gap-2 mb-4">
+            <p class="label">영화 평점 분포</p>
+            <a href={`${base}/movies/`} class="text-xs font-mono" style="color: var(--text-3)">영화 목록 →</a>
+          </div>
+          <GenreChart data={movieRatingDist} />
+          {tmdbMovies.length > 0 && (
+            <p class="text-[11px] font-mono mt-3" style="color: var(--text-3)">
+              TMDB보다 높게: {higherThanTmdb}편 · 낮게: {lowerThanTmdb}편 · 동일: {sameTmdb}편
+            </p>
+          )}
+        </div>
+      )}
+      {bookRatingDist.length > 0 && (
+        <div class="stat-box">
+          <div class="flex items-baseline justify-between gap-2 mb-4">
+            <p class="label">책 평점 분포</p>
+            <a href={`${base}/books/`} class="text-xs font-mono" style="color: var(--text-3)">책 목록 →</a>
+          </div>
+          <GenreChart data={bookRatingDist} />
+        </div>
+      )}
+    </section>
+  )}
+
+  <!-- ── 개봉/출판 연도 분포 ─────────────────────────────────────────────────── -->
+  {(hasMovieYearData || hasBookYearData) && (
+    <section class="mb-14 grid gap-8 lg:grid-cols-2">
+      {hasMovieYearData && (
+        <div class="stat-box">
+          <p class="label mb-4">시청 영화 개봉 연도</p>
+          <GenreChart data={movieYearDist} />
+        </div>
+      )}
+      {hasBookYearData && (
+        <div class="stat-box">
+          <p class="label mb-4">읽은 책 출판 연도</p>
+          <GenreChart data={bookYearDist} />
+        </div>
+      )}
+    </section>
+  )}
+
+  <!-- ── 장르 / 주제 차트 ──────────────────────────────────────────────────── -->
   <section class="mb-14 grid gap-8 lg:grid-cols-2">
     <div class="stat-box">
       <div class="flex items-baseline justify-between gap-2 mb-4">
@@ -160,25 +420,61 @@ const base = rawBase.endsWith('/') ? rawBase.slice(0, -1) : rawBase;
     </div>
   </section>
 
+  <!-- ── 요일별 영화 시청 패턴 ────────────────────────────────────────────── -->
+  {hasWeekdayData && (
+    <section class="mb-14">
+      <div class="stat-box">
+        <p class="label mb-4">요일별 영화 시청</p>
+        <GenreChart data={weekdayData} />
+        <p class="text-xs font-mono mt-3" style="color: var(--text-3)">
+          시청일 기준 (날짜 미상 제외)
+        </p>
+      </div>
+    </section>
+  )}
+
+  <!-- ── 월별 활동 (스택드 바) ─────────────────────────────────────────────── -->
   <section class="stat-box">
     <p class="label mb-4">최근 12개월 활동</p>
     <div class="space-y-2.5">
-      {monthlyRows.map(row => (
-        <div class="flex items-center gap-3">
-          <span class="text-xs font-mono w-12 shrink-0" style="color: var(--text-3)">{row.label}</span>
-          <div class="flex-1 h-2 rounded-full overflow-hidden" style="background: var(--border);">
-            <div class="h-full rounded-full"
-                 style={`width:${(row.total / maxMonthlyTotal * 100).toFixed(1)}%; background: var(--accent);`} />
+      {monthlyRows.map(row => {
+        const moviePct = (row.movieCount / maxMonthlyTotal * 100).toFixed(1);
+        const bookPct  = (row.bookCount  / maxMonthlyTotal * 100).toFixed(1);
+        return (
+          <div class="flex items-center gap-3">
+            <span class="text-xs font-mono w-12 shrink-0" style="color: var(--text-3)">{row.label}</span>
+            <div class="flex-1 h-2 rounded-full overflow-hidden flex" style="background: var(--border);">
+              {/* 책 (앞쪽, 옅은 gold) */}
+              {row.bookCount > 0 && (
+                <div class="h-full"
+                     style={`width:${bookPct}%; background: var(--accent); opacity: 0.45;`} />
+              )}
+              {/* 영화 (뒤쪽, 진한 gold) */}
+              {row.movieCount > 0 && (
+                <div class="h-full"
+                     style={`width:${moviePct}%; background: var(--accent);`} />
+              )}
+            </div>
+            <span class="text-xs font-mono w-20 text-right shrink-0" style="color: var(--text-2)">
+              {row.movieCount > 0 && <span>{row.movieCount}편</span>}
+              {row.movieCount > 0 && row.bookCount > 0 && <span style="color: var(--text-3)"> · </span>}
+              {row.bookCount > 0 && <span style="opacity: 0.7">{row.bookCount}권</span>}
+              {row.total === 0 && <span style="color: var(--text-3)">—</span>}
+            </span>
           </div>
-          <span class="text-xs font-mono w-16 text-right shrink-0" style="color: var(--text-2)">
-            {row.total}개
-          </span>
-        </div>
-      ))}
+        );
+      })}
     </div>
-    <p class="text-xs font-mono mt-4" style="color: var(--text-3)">
-      영화/책 완료일 기준 합산입니다.
-    </p>
+    <div class="flex items-center gap-4 mt-4 text-[11px] font-mono" style="color: var(--text-3)">
+      <span class="flex items-center gap-1.5">
+        <span class="inline-block w-3 h-1.5 rounded-full" style="background: var(--accent);"></span>
+        영화
+      </span>
+      <span class="flex items-center gap-1.5">
+        <span class="inline-block w-3 h-1.5 rounded-full" style="background: var(--accent); opacity: 0.45;"></span>
+        책
+      </span>
+    </div>
   </section>
 </BaseLayout>
 
@@ -188,5 +484,22 @@ const base = rawBase.endsWith('/') ? rawBase.slice(0, -1) : rawBase;
     background: var(--surface);
     border-radius: 8px;
     padding: 1rem;
+  }
+
+  .highlight-card {
+    position: relative;
+    overflow: hidden;
+  }
+
+  /* 하이라이트 카드 상단 accent 라인 */
+  .highlight-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--accent);
+    opacity: 0.6;
   }
 </style>


### PR DESCRIPTION
## Summary

- **MovieCard**: 시네마틱 오버레이 (제목/장르칩/런타임 배지), 모바일 포함 `aspect-[2/3]` 통일
- **BookCard**: 3D perspective tilt 제거, MovieCard와 동일한 깔끔한 플랫 카드 구조로 통일
- **HeatmapCalendar**: 영화(gold)/책(steel-blue)/둘다(purple) 색상 분리, 이벤트 기반 마킹(구매일+완독일만), intensity level 제거
- **StatsPanel**: 항상 3열 레이아웃 (`sm:` 브레이크포인트 제거로 모바일도 1줄)
- **stats.astro**: reading_days 통계 제거, 하이라이트 카드 (책 높이/두꺼운 책/최장 영화/내 최애), 평점 분포/요일 패턴/개봉연도/스택 월별 바 차트 추가
- **NavBar**: 외부 블로그 링크 추가 (kbsooo.github.io)
- **data/books.json**: 영어 책 표지 URL 및 메타데이터 백필

## Test plan

- [ ] 빌드 통과 (`astro build`)
- [ ] 메인 페이지: stats 3열, heatmap 색상 구분 확인
- [ ] 영화/책 페이지: 카드 비율 및 오버레이 확인
- [ ] 모바일(375px): 카드 높이, stats 1줄 확인
- [ ] 통계 페이지: 새 차트 섹션 확인
- [ ] 다크모드: heatmap 색상 변형 확인
- [ ] NavBar 블로그 링크 새 탭으로 열리는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)