### PR TITLE
fix: prevent horizontal scroll on mobile navbar

### DIFF
--- a/src/src/components/NavBar.astro
+++ b/src/src/components/NavBar.astro
@@ -16,7 +16,7 @@ const currentPath = Astro.url.pathname;
 
 <nav style="background: var(--bg); border-bottom: 1px solid var(--border);"
      class="sticky top-0 z-50 backdrop-blur-sm">
-  <div class="max-w-6xl mx-auto px-5 sm:px-8 lg:px-10 h-12 flex items-center justify-between gap-6">
+  <div class="max-w-6xl mx-auto px-3 sm:px-8 lg:px-10 h-12 flex items-center justify-between gap-2 sm:gap-6">
 
     <!-- Brand -->
     <a href={`${base}/`} class="font-semibold text-sm tracking-tight shrink-0"
@@ -32,7 +32,7 @@ const currentPath = Astro.url.pathname;
         return (
           <a
             href={link.href}
-            class="px-3 py-1.5 rounded-md text-sm transition-colors"
+            class="px-2 sm:px-3 py-1.5 rounded-md text-sm transition-colors"
             style={isActive
               ? `color: var(--accent); font-weight: 600;`
               : `color: var(--text-2);`}

--- a/src/src/styles/global.css
+++ b/src/src/styles/global.css
@@ -42,6 +42,7 @@
   body {
     word-break: keep-all;
     overflow-wrap: break-word;
+    overflow-x: hidden;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     background-color: var(--bg);


### PR DESCRIPTION
## Summary
- `NavBar.astro`: 모바일 컨테이너 패딩을 `px-5` → `px-3`으로, gap을 `gap-6` → `gap-2 sm:gap-6`으로 축소
- `NavBar.astro`: 각 nav 링크 패딩을 `px-3` → `px-2 sm:px-3`으로 축소
- `global.css`: `body`에 `overflow-x: hidden` 추가 (안전망)

## Test plan
- [ ] 모바일(375px 이하) 환경에서 가로 스크롤 미발생 확인
- [ ] 데스크탑에서 기존 레이아웃 유지 확인 (`sm:` breakpoint 이상에서 원래 padding/gap 적용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)