### PR TITLE
fix: deploy not triggered after issue close

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,10 +25,7 @@ jobs:
   build:
     if: |
       github.event_name != 'workflow_run' ||
-      (
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.head_branch == 'main'
-      )
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (push/manual)


### PR DESCRIPTION
## Summary
- `deploy.yml`의 build job `if` 조건에서 `head_branch == 'main'` 체크 제거
- `issues: [closed]` 이벤트로 트리거된 워크플로는 `workflow_run` 컨텍스트에서 `head_branch`가 `null`이 되어, 조건이 항상 `false`로 평가되어 build job이 skip되는 버그 수정

## Root Cause
`Process Issue` 워크플로는 이슈 이벤트로 실행되므로 특정 브랜치와 연결되지 않아 `workflow_run.head_branch`가 `null`로 설정됨. 이로 인해 `workflow_run` 트리거 시 build job이 항상 skip되어 배포가 이루어지지 않았음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)