### PR TITLE
fix: explicitly dispatch deploy workflow after data commit

### DIFF
--- a/.github/workflows/backfill-issues.yml
+++ b/.github/workflows/backfill-issues.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: write
   issues: read
+  actions: write
 
 concurrency:
   group: process-issue-main
@@ -35,14 +36,29 @@ jobs:
         run: node scripts/backfill-issues.mjs
 
       - name: Commit updated data files
+        id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/movies.json data/books.json
           if git diff --cached --quiet; then
             echo "No data changes to commit."
+            echo "data_changed=false" >> $GITHUB_OUTPUT
             exit 0
           fi
           git commit -m "chore: backfill closed issues"
           git pull --rebase origin main
           git push origin HEAD:main
+          echo "data_changed=true" >> $GITHUB_OUTPUT
+
+      - name: Trigger deploy
+        if: steps.commit.outputs.data_changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deploy.yml',
+              ref: 'main',
+            });

--- a/.github/workflows/process-issue.yml
+++ b/.github/workflows/process-issue.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   issues: read
+  actions: write
 
 concurrency:
   group: process-issue-main
@@ -52,14 +53,29 @@ jobs:
         run: node scripts/process-book.mjs
 
       - name: Commit updated data files
+        id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/movies.json data/books.json
           if git diff --cached --quiet; then
             echo "No data changes to commit."
+            echo "data_changed=false" >> $GITHUB_OUTPUT
             exit 0
           fi
           git commit -m "chore: add entry from issue #${{ github.event.issue.number }}"
           git pull --rebase origin main
           git push origin HEAD:main
+          echo "data_changed=true" >> $GITHUB_OUTPUT
+
+      - name: Trigger deploy
+        if: steps.commit.outputs.data_changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deploy.yml',
+              ref: 'main',
+            });


### PR DESCRIPTION
GITHUB_TOKEN으로 push할 때 push 이벤트가 다른 워크플로우를 트리거하지
않는 GitHub 제한 때문에, workflow_run만으로는 배포가 불안정할 수 있음.

데이터 변경이 실제로 발생한 경우에만 deploy.yml을 명시적으로 dispatch해서
배포를 보장. data_changed output으로 불필요한 dispatch 방지.

https://claude.ai/code/session_01D3rLxeyNLancna5xnbUf6z